### PR TITLE
Add hidden param to toggleterm command

### DIFF
--- a/lua/atac/ui.lua
+++ b/lua/atac/ui.lua
@@ -15,6 +15,7 @@ function M.toggle_atac_terminal()
 		-- Create a floating terminal pane and run a custom command
 		atac_term = Terminal:new({
 			cmd = "atac -d " .. M.options.dir,
+			hidden = true,
 			direction = "float",
 			float_opts = { border = "double" },
 			on_open = function(term)


### PR DESCRIPTION
Hi! 

I just added the `hidden = true` param to `Terminal:new` (https://github.com/akinsho/toggleterm.nvim#custom-terminal-usage) so the terminal will not be toggled by normal toggleterm commands such as `:ToggleTerm`.

Thanks a lot for your work on this plugin! :sparkles: 